### PR TITLE
Use font filename rather than full path

### DIFF
--- a/pop-fe.py
+++ b/pop-fe.py
@@ -43,12 +43,10 @@ from popstation import popstation
 
 PSX_SITE = 'https://psxdatacenter.com/'
 verbose = False
-font = '/usr/share/fonts/dejavu/DejaVuSansMono.ttf'
-try:
-    os.stat(font)
-except:
-    font = '/c/Windows/Fonts/arial.ttf'
-    os.stat(font)
+if sys.platform == 'win32':
+    font = 'arial.ttf'
+else:
+    font = 'DejaVuSansMono.ttf'
 
 def get_gameid_from_iso():
     if not have_pycdlib and not have_iso9660:


### PR DESCRIPTION
Font path on Debian 11 is .../fonts/truetype/dejavu/... rather than .../fonts/dejavu/... so was failing over to the Windows path and throwing an exception. Using only the file name leaves PIL to handle finding the path. Only tested on Debian 11.