### PR TITLE
Adding CHDMAN to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /pop-fe
 RUN apt-get update && apt-get install -y \
   libsndfile-dev \
   ffmpeg \
+  mame-tools \
   cmake && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The Dockerfile currently missing CHDMAN and fails to convert from .chd format. This commit fixes it by adding the package mame-tools.


