### PR TITLE
Refactor document encryption/decryption

### DIFF
--- a/document.py
+++ b/document.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 # coding: utf-8
-#
-# A utility to automate building PS3 and PSP Document files
-# Based on PSP Docmaker GUI by takedown psp.in.th
 
 try:
     from Crypto.Cipher import DES
     from Crypto.Cipher import AES
 except:
-    print('Crypto is not installed.\nYou should install Crypto by running:\npip3 install Crypto')
+    print('Crypto is not installed.\nYou should install Crypto by running:\npip3 install pycryptodome')
+
 try:
     from PIL import Image, ImageDraw, ImageFont
 except:
-    print('You need to install python module pillow')
+    print('Pillow is not installed.\nYou should install Pillow by running:\npip3 install pillow')
+
 import argparse
 import hashlib
 import io
@@ -37,10 +36,10 @@ pgd_hdr = bytes([0x00, 0x50, 0x47, 0x44, 0x01, 0x00, 0x00, 0x00,
 ### BBOX minimal implementation for encrypted PS1 DOCUMENT.DAT ###
 
 class BBoxException(Exception):
-    def __init__(self, code: int, message: str = ''):
+    def __init__(message: str = ''):
         super().__init__(message or f'BBox Error')
 
-def _raise(code: int, msg: str) -> None:
+def _raise(msg: str) -> None:
     raise BBoxException(msg)
 
 KEY_VAULT = {
@@ -54,6 +53,17 @@ def _encrypt_iv0(data: bytes, keyseed: int) -> bytes:
 
 def _decrypt_iv0(data: bytes, keyseed: int) -> bytes:
     return AES.new(KEY_VAULT[keyseed], AES.MODE_CBC, b'\x00' * 16).decrypt(data)
+
+def _decrypt_des(input_data: bytes) -> bytes:
+    cipher = DES.new(des_key, DES.MODE_CBC, des_iv)
+    return cipher.decrypt(input_data)
+
+def _encrypt_des(data: bytes) -> bytes:
+    cipher = DES.new(des_key, DES.MODE_CBC, des_iv)
+    return cipher.encrypt(data)
+
+def sha1hash(data: bytes) -> bytes:
+    return hashlib.sha1(data).digest()[:0x10]
 
 def gen_pad(buf: bytes, block_size: int = 16) -> bytes:
     return buf + b'\x00' * (-len(buf) % block_size)
@@ -164,147 +174,201 @@ def pops_get_secure_install_id(buf: bytes) -> bytes:
         _raise('buf must be 0x70 bytes')
     
     mkey = MACKey(key=bytearray(16), pad=bytearray(16), pad_size=0)
+    
     BBMacInit(mkey)
     BBMacUpdate(mkey, buf[:0x60])
+    
     id_out = bbmac_getkey(mkey, buf[0x60:0x70])
+    
     return id_out
 
-def boxbb_mac_gen(buf: bytes, vkey: bytes) -> bytes:
+def bbox_mac_gen(buf: bytes, vkey: bytes) -> bytes:
     if len(vkey) != 16:
         _raise('version_key must be 16 bytes')
     
     buf = bytes(buf)
     tmp = bytearray(16)
+    
     mkey = MACKey(key=bytearray(16), pad=bytearray(16), pad_size=0)
+    
     BBMacInit(mkey)
     BBMacUpdate(mkey, buf)
     BBMacFinal(mkey, tmp, vkey)
+    
     return bytes(tmp)
 
-def boxbb_mac_gen_enc(buf: bytes, vkey: bytes) -> bytes:
-    get_bb_mac =  boxbb_mac_gen(buf, vkey)
+def bbox_mac_gen_enc(buf: bytes, vkey: bytes) -> bytes:
+    get_bb_mac = bbox_mac_gen(buf, vkey)
     return _encrypt_iv0(get_bb_mac, 0x63)
 
 # set standard keys (POPS "VERSION" KEY)
 ins_id = bytes([0x2E, 0x41, 0x17, 0xA5, 0x32, 0xE6, 0xC4, 0x73, 0x71, 0x7B, 0x0F, 0x7A, 0x6E, 0xC0, 0xAA, 0xA5])
+
 ###################
 
-def decrypt_blob(hdr, name):
-    cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-    msg = cipher.decrypt(hdr[:-32])
-    if hashlib.sha1(hdr[:-32]).digest()[:16] != hdr[-16:]:
-        print('SHA1 mismatch')
-        os._exit(1)
-    return msg
-
-
 def decrypt_document(data, directory):
-    #
+    # PGD Header
+    hdr = data[:0x10]
+    if hdr != pgd_hdr:
+        print('PGD magic mismatch')
+        os._exit(1)
+    
     # DOC Header
-    #
-    offset = 0x10
-    length = 0x60
-    hdr = data[offset:offset + length + 0x20]
-    msg = decrypt_blob(hdr, 'DOC Header')
+    o = 0x10
+    l = 0x60
+    
+    hdr = data[o:o+l]
+    mac = data[o+l:o+l+0x10]
+    sha1 = data[o+l+0x10:o+l+0x20]
+    ins = pops_get_secure_install_id(hdr + mac)
+    
+    # if mac != b'\0' * 8:
+    #     if mac != bbox_mac_gen_enc(hdr, ins):
+    #         print('DOC Header BB MAC mismatch')
+    #         os._exit(1)
+    
+    if sha1hash(hdr) != sha1:
+        print('DOC Header SHA1 mismatch')
+        os._exit(1)
+    
+    msg = _decrypt_des(hdr)
+    
     if msg[:4] != b'DOC ':
-        print('Magic mismatch')
+        print('DOC magic mismatch')
         os._exit(1)
-    if struct.unpack_from('<I', msg, 0x04)[0] != 0x00010000 or struct.unpack_from('<I', msg, 0x08)[0] != 0x00010000:
-        print('Unk mismatch')
+    
+    if msg[0x04:0x0C] != b'\0\0\1\0\0\0\1\0':
+        print('Unknown mismatch')
         os._exit(1)
-    print('Gameid', msg[0x0c:0x1c])
-    info_block_size = 0x1f3e8 if struct.unpack_from('<I', msg, 0x1c)[0] else 0x31e8
-          
-    #
+    
+    print('Game ID:', msg[0x0C:0x1C].decode().rstrip('\0'))
+    
+    big_flag = struct.unpack_from('<I', msg, 0x1C)[0]
+    info_block_size = 0x1f3e8 if big_flag else 0x31e8
+    
     # INFO Block
-    #
-    offset = 0x90
-    length = info_block_size
-    hdr = data[offset:offset + length + 0x20]
-    msg = decrypt_blob(hdr, 'Info block (small)')
-    if struct.unpack_from('<I', msg, 0x00)[0] != 0xffffffff:
+    o = 0x90
+    l = info_block_size
+    
+    hdr = data[o:o+l]
+    mac = data[o+l:o+l+0x10]
+    sha1 = data[o+l+0x10:o+l+0x20]
+    
+    # if mac != b'\0' * 8:
+    #     if mac != bbox_mac_gen_enc(hdr, ins):
+    #         print('INFO Block BB MAC mismatch')
+    #         os._exit(1)
+    
+    if sha1hash(hdr) != sha1:
+        print('INFO Block SHA1 mismatch')
+        os._exit(1)
+    
+    msg = _decrypt_des(hdr)
+    
+    if msg[0:4] != b'\xFF' * 4:
         print('Marker mismatch')
         os._exit(1)
-    psp_image_count = struct.unpack_from('<I', msg, 0x04)[0]
-    print('Image count 0x%08x PSP?' % (psp_image_count))
-    ps3_image_count = struct.unpack_from('<I', msg, 0x3188)[0]
-    print('Image count 0x%08x PS3' % (ps3_image_count))
     
-    for i in range(ps3_image_count):
-        psp_fp = struct.unpack_from('<I', msg, 0x08 + i * 0x80)[0]
-        psp_es = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x0c)[0]
-        ps3_fp = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x10)[0]
-        ps3_es = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x1c)[0]
-        offset = ps3_fp
-        length = ps3_es
-        hdr = data[offset:offset + length]
-
-        if hashlib.sha1(hdr[:-32]).digest()[:16] != hdr[-16:]:
-            print('PNG SHA1 mismatch')
-            os._exit(1)
-
-        cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-        png_info_head = cipher.decrypt(hdr[:0x20])
+    psp_image_count = struct.unpack_from('<I', msg, 0x04)[0]
+    ps3_image_count = struct.unpack_from('<I', msg, 0x1f388 if big_flag else 0x3188)[0]
+    
+    print('Image Count PSP:', psp_image_count)
+    print('Image Count PS3:', ps3_image_count)
+    
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    
+    for i in range(psp_image_count):
+        psp_o = struct.unpack_from('<I', msg, 0x08 + i * 0x80)[0]
+        psp_l = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x0C)[0]
+        ps3_o = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x10)[0]
+        ps3_l = struct.unpack_from('<I', msg, 0x08 + i * 0x80 + 0x1C)[0]
         
-        enc_chunks = struct.unpack_from('<I', png_info_head, 0x08)[0]
-        png_size = struct.unpack_from('<I', png_info_head, 0x00)[0]
-        write_size = png_size - (8 * enc_chunks) - 0x40;
-
-        cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-        png_head = cipher.decrypt(hdr[0x20:0x20 + 8 * enc_chunks])
-
-        png = hdr[0x20 + 8 * enc_chunks:][:write_size]
+        offset = psp_o
+        length = psp_l
+        
+        page_buf  = bytearray(data[offset:offset + length])
+        page_mac  = page_buf[-0x20:][:0x10]
+        page_sha1 = page_buf[-0x20:][-0x10:]
+        page_buf  = page_buf[:-0x20]
+        
+        # if page_mac != b'\0' * 8:
+        #     if page_mac != bbox_mac_gen_enc(page_buf, ins):
+        #         print(f'Page {i+1:03d}: BB MAC mismatch')
+        #         continue
+        
+        if sha1hash(page_buf) != page_sha1:
+            print(f'Page {i+1:03d}: SHA1 mismatch')
+            continue
+        
+        page_info_head = _decrypt_des(page_buf[:0x20])
+        page_size = struct.unpack_from('<I', page_info_head, 0x00)[0]
+        enc_chunks = struct.unpack_from('<I', page_info_head, 0x08)[0]
+        
+        if page_size != length:
+            print(f'Page {i+1:03d}: size mismatch')
+            continue
+        
+        payload_offset = 0x20 + enc_chunks * 0x08
+        subheader = _decrypt_des(page_buf[0x20:payload_offset])
+        page_buf = page_buf[payload_offset:]
+        
         for k in range(enc_chunks):
-                dec_size = struct.unpack_from('<I', png_head, k * 8 + 4)[0]
-                dec_offset = struct.unpack_from('<I', png_head, k * 8 + 0)[0]
-
-                cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-                _b = cipher.decrypt(png[dec_offset:dec_offset + dec_size])
-                png = png[:dec_offset] + _b + png[dec_offset + dec_size:]
-
-        print('Extracting %s/%03d.png' % (directory, i))
-        with open('%s/%03d.png' % (directory, i), 'wb') as f:
-            f.write(png)
-
+            dec_o = struct.unpack_from('<I', subheader, k * 8 + 0)[0]
+            dec_s = struct.unpack_from('<I', subheader, k * 8 + 4)[0]
+            
+            dec_chunk = _decrypt_des(page_buf[dec_o:dec_o + dec_s])
+            page_buf[dec_o:dec_o + dec_s] = dec_chunk
+        
+        print('Extracting %s/%03d.png' % (directory, i+1))
+        
+        needle_buf = b'IEND\xAE\x42\x60\x82'
+        needle_idx = page_buf.rfind(needle_buf)
+        
+        if needle_idx == -1:
+            print(f'Page {page_index+1:03d}: PNG trailer not found')
+            continue
+        
+        png_size = needle_idx + len(needle_buf)
+        if png_size < 0x43:
+            print(f'Page {page_index+1:03d}: PNG too small or trailer found too early (size={png_size})')
+            continue
+        
+        with open('%s/%03d.png' % (directory, i+1), 'wb') as f:
+            f.write(page_buf[:png_size])
 
 def encrypt_document(f, gameid, pages):
-    def create_header(gameid):
+    def create_header(gameid, pages):
         buf = bytearray(0x60)
         struct.pack_into('<I', buf, 0x00, 0x20434F44)
         struct.pack_into('<I', buf, 0x04, 0x10000)
         struct.pack_into('<I', buf, 0x08, 0x10000)
-        buf[12:21] = bytes(gameid, encoding='utf-8')
+        buf[0x0C:0x1C] = gameid.encode('ascii')[:0x0F].ljust(0x10, b'\x00')
         struct.pack_into('<I', buf, 0x1c, 0)
         struct.pack_into('<I', buf, 0x1c, 0 if len(pages) < 100 else 1)
         return buf
     
     print('Encrypt', gameid)
-    info_block_size = 0x1f3e8 if len(pages) >= 100 else 0x31e8
-
-    #
+    
     # PGD header
-    #
     f.write(pgd_hdr)
-
-    #
+    
     # DOC Header
-    #
-    hdr = create_header(gameid)
-    cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-    msg = cipher.encrypt(bytes(hdr))
-
-    msg = msg + boxbb_mac_gen_enc(msg, ins_id) + hashlib.sha1(msg).digest()[:16]
+    hdr = create_header(gameid, pages)
+    
+    msg = _encrypt_des(bytes(hdr))
+    msg = msg + bbox_mac_gen_enc(msg, ins_id) + sha1hash(msg)
     f.write(msg)
-
-    #
+    
     # Info Block
     # file data starts at 0x3298 / 0x1f498
-    #
+    info_block_size = 0x1f3e8 if len(pages) >= 100 else 0x31e8
     fp = info_block_size + 0x20 + 0x90 
     ib = bytearray(info_block_size)
+    
     struct.pack_into('<I', ib, 0x00, 0xffffffff)
     struct.pack_into('<I', ib, 0x04, len(pages))
     struct.pack_into('<I', ib, 0x3188 if len(pages) < 100 else 0x1f388, len(pages))
+    
     for i, p in enumerate(pages):
         png_len = len(p) + 0x20
         struct.pack_into('<I', ib, 0x08 + i * 0x80 + 0x00, fp)
@@ -312,32 +376,26 @@ def encrypt_document(f, gameid, pages):
         struct.pack_into('<I', ib, 0x08 + i * 0x80 + 0x10, fp)
         struct.pack_into('<I', ib, 0x08 + i * 0x80 + 0x1c, png_len + 0x20)
         fp += png_len + 0x20
-    cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-    msg = cipher.encrypt(bytes(ib))
-
-    msg = msg + boxbb_mac_gen_enc(msg, ins_id) + hashlib.sha1(msg).digest()[:16]
+    
+    msg = _encrypt_des(bytes(ib))
+    msg = msg + bbox_mac_gen_enc(msg, ins_id) + sha1hash(msg)
     f.write(msg)
-
-    #
+    
     # File data
-    #
     fp = info_block_size + 0x20 + 0x90 
     for i, p in enumerate(pages):
-        print('Encrypting and writing pic', i)
+        print(f'Encrypting and writing page {i+1:03d}')
         png_len = len(p) + 0x20
         
         png_info_head = bytearray(0x20)
         struct.pack_into('<I', png_info_head, 0, png_len + 0x20)
-        cipher = DES.new(des_key, DES.MODE_CBC, IV=des_iv)
-        png_info_head = cipher.encrypt(bytes(png_info_head))
-
+        png_info_head = _encrypt_des(bytes(png_info_head))
+        
         p = png_info_head + p
-        p = p + boxbb_mac_gen_enc(p, ins_id) + hashlib.sha1(p).digest()[:16]
-
+        p = p + bbox_mac_gen_enc(p, ins_id) + sha1hash(p)
+        
         f.write(p)
         fp += len(p)
-
-
 
 def create_document(f, gameid, pages):
     def create_header(gameid, pages):
@@ -345,7 +403,7 @@ def create_document(f, gameid, pages):
         struct.pack_into('<I', buf, 0, 0x20434F44)
         struct.pack_into('<I', buf, 4, 0x10000)
         struct.pack_into('<I', buf, 8, 0x10000)
-        buf[12:21] = bytes(gameid, encoding='utf-8')
+        buf[0x0C:0x1C] = gameid.encode('ascii')[:0x0F].ljust(0x10, b'\x00')
         struct.pack_into('<I', buf, 28, 0 if len(pages) < 100 else 1)
         struct.pack_into('<I', buf, 128, 0xffffffff)
         struct.pack_into('<I', buf, 132, len(pages))
@@ -355,33 +413,32 @@ def create_document(f, gameid, pages):
         buf = bytearray(128)
         struct.pack_into('<I', buf, 0, pos) # offset low
         struct.pack_into('<I', buf, 12, len(p)) # size low
-
+        
         return buf
-
+    
     f.write(create_header(gameid, pages)) # size 0x88
     for i in range(len(pages)):
         f.write(bytes(128))              # size 0x80
         f.write(bytes(8))                # size 0x08, padding
         
     for idx, p in enumerate(pages):
-            b = generate_document_entry(p, f.tell())
-            f.seek(0x88 + 0x80 * idx)
-            f.write(b)
-            f.seek(0, 2)
-            f.write(p)
+        b = generate_document_entry(p, f.tell())
+        f.seek(0x88 + 0x80 * idx)
+        f.write(b)
+        f.seek(0, 2)
+        f.write(p)
 
-            
 def view_document(document, page):
     with open(document, 'rb') as i:
         buf = i.read(136)
-
+        
         if struct.unpack_from('<I', buf, 0)[0] != 0x20434F44:
-            print('Not a DOCUMENT.DAT file')
+            print('Not a Decrypted PS1 DOCUMENT.DAT file')
             exit
-    
+        
         num_pages = struct.unpack_from('<I', buf, 132)[0]
         print('Num pages:', num_pages)
-
+        
         i.seek(136 + 128 * page)
         buf = i.read(128)
         offset_low = struct.unpack_from('<I', buf, 0)[0]
@@ -389,51 +446,45 @@ def view_document(document, page):
         print('offset:', offset_low)
         print('size:', size_low)
         i.seek(offset_low)
-
+        
         image = Image.open(io.BytesIO(i.read(size_low)))
         image.show()
-
 
 def extract_document(document, output):
     with open(document, 'rb') as i:
         buf = i.read(136)
-
+        
         if struct.unpack_from('<I', buf, 0)[0] != 0x20434F44:
-            print('Not a DOCUMENT.DAT file')
+            print('Not a Decrypted PS1 DOCUMENT.DAT file')
             exit
-    
+        
         num_pages = struct.unpack_from('<I', buf, 132)[0]
         print('Num pages:', num_pages)
-
+        
         for page in range(num_pages):
-            print('Extracting', page, 'to', output + '/%04d.png' % page)
-
+            print(f'Extracting {page+1:03d} to {output}/{page+1:03d}.png')
+            
             i.seek(136 + 128 * page)
             buf = i.read(128)
             offset_low = struct.unpack_from('<I', buf, 0)[0]
             size_low = struct.unpack_from('<I', buf, 12)[0]
             i.seek(offset_low)
-
-            with open(output + '/%04d.png' % page, 'wb') as o:
+            
+            with open(output + '/%03d.png' % page + 1, 'wb') as o:
                 o.write(i.read(size_low))
 
 def create_document_from_dir(gameid, dir, doc):
-        pages = []
-        for png in sorted(Path(dir).iterdir()):
-            image = Image.open(png)
-            maxysize = 480
-            sf = 480 / image.size[0]
-            ns = (480, int(sf * image.size[1]))
-            if ns[1] > maxysize:
-                ns = (480, maxysize)
-            image = image.resize(ns, Image.Resampling.LANCZOS)
-            f = io.BytesIO()
-            image.save(f, 'PNG')
-            f.seek(0)
-            pages.append(f.read())
-        with open(doc, 'wb') as f:
-            create_document(f, gameid if gameid else 'UNKN00000', pages)
-        
+    pages = []
+    for png in sorted(Path(dir).iterdir()):
+        image = Image.open(png)
+        image.thumbnail((480, 480), Image.Resampling.LANCZOS)
+        f = io.BytesIO()
+        image.save(f, 'PNG')
+        f.seek(0)
+        pages.append(f.read())
+    with open(doc, 'wb') as f:
+        create_document(f, gameid if gameid else 'UNKN00000', pages)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', action='store_true', help='Verbose')
@@ -462,6 +513,7 @@ if __name__ == "__main__":
         if not args.document:
             print('Must specify --document')
             os._exit(1)
+    
     if args.command[0] == 'create':
         print('Create', args.document)
         create_document_from_dir(args.gameid, args.directory, args.document)
@@ -501,22 +553,12 @@ if __name__ == "__main__":
         pages = []
         for png in sorted(Path(args.directory).iterdir()):
             image = Image.open(png)
-            maxysize = 480
-            sf = 480 / image.size[0]
-            ns = (480, int(sf * image.size[1]))
-            if ns[1] > maxysize:
-                ns = (480, maxysize)
-            image = image.resize(ns, Image.Resampling.LANCZOS)
+            image.thumbnail((480, 480), Image.Resampling.LANCZOS)
             f = io.BytesIO()
             image.save(f, 'PNG')
             f.seek(0)
             pages.append(gen_pad(f.read()))
         with open(args.document, 'wb') as f:
             encrypt_document(f, args.gameid if args.gameid else 'UNKN00000', pages)
-        
-        # keysbin = str(Path(args.document).parent) + '/KEYS.BIN'
-        # print('Save keys', keysbin)
-        # with open(keysbin, 'wb') as f:
-        #     f.write(ins_id)
         
         sys.exit()


### PR DESCRIPTION
I’ve commented out the BB MAC digests checks for now, because most likely there are already some created without a BB MAC digests.

Also, we should change naming for document.dat types:
for decrypted type, use "decrypted ps1 document.dat"
for encrypted type, just use "ps1 document.dat"
see: https://www.psdevwiki.com/ps3/DOCUMENT.DAT#Remarks_on_deprecated_naming_convention